### PR TITLE
Update show data when possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Update show data on progress page request. #12
+### Added
+- Update show data on progress page load. #12
+- Update show data when clicking next button. #14
 
 ### Removed
 - flake8 noqa. #11

--- a/project/apps/accounts/models.py
+++ b/project/apps/accounts/models.py
@@ -81,6 +81,8 @@ class User(AbstractBaseUser, PermissionsMixin, BaseUUIDModel):
             - next_season
             - next_episode
             - next_air_date
+            - last_aired_season
+            - last_aired_episode
         """
         progresses_data = self._get_updated_progresses_data()
         next_air_dates = self._get_next_air_dates(progresses_data)

--- a/project/apps/tmdb/forms.py
+++ b/project/apps/tmdb/forms.py
@@ -32,7 +32,7 @@ class ProgressForm(forms.ModelForm):
         if not instance:
             return
 
-        update_fields = ["show_id", "show_name", "show_poster_path", "show_status"]
+        update_fields = ["show_name", "show_poster_path", "show_status"]
         instance.__dict__.update(
             **{key: value for key, value in initial.items() if key in update_fields}
         )

--- a/project/apps/tmdb/models.py
+++ b/project/apps/tmdb/models.py
@@ -154,7 +154,16 @@ class Progress(BaseModel):
         self.show_name = self.show.name
         self.show_poster_path = self.show.poster_path
         self.show_status = self.show.status_value
-        self.save(update_fields=["show_name", "show_poster_path", "show_status"])
+        self.last_aired_season, self.last_aired_episode = self.show.last_aired_episode
+        self.save(
+            update_fields=[
+                "show_name",
+                "show_poster_path",
+                "show_status",
+                "last_aired_season",
+                "last_aired_episode",
+            ]
+        )
 
     def watch_next(self):
         self._update_episodes()
@@ -180,6 +189,3 @@ class Progress(BaseModel):
             self.next_air_date = get_air_date(self.show_id, self.next_season, self.next_episode)
         else:
             self.next_air_date = None
-
-    def update_last_aired_episode(self):
-        self.last_aired_season, self.last_aired_episode = self.show.last_aired_episode

--- a/project/apps/tmdb/models.py
+++ b/project/apps/tmdb/models.py
@@ -150,10 +150,24 @@ class Progress(BaseModel):
             return None
         return format_episode_label(self.last_aired_season, self.last_aired_episode)
 
+    def update_show_data(self):
+        self.show_name = self.show.name
+        self.show_poster_path = self.show.poster_path
+        self.show_status = self.show.status_value
+        self.save(update_fields=["show_name", "show_poster_path", "show_status"])
+
     def watch_next(self):
         self._update_episodes()
         self.update_next_air_date()
-        self.save()
+        self.save(
+            update_fields=[
+                "current_season",
+                "current_episode",
+                "next_season",
+                "next_episode",
+                "next_air_date",
+            ]
+        )
 
     def _update_episodes(self):
         self.current_season, self.current_episode = self.next_season, self.next_episode

--- a/project/apps/tmdb/tests/test_forms.py
+++ b/project/apps/tmdb/tests/test_forms.py
@@ -1,5 +1,7 @@
 import pytest
 
+from project.apps.accounts.tests.factories import UserFactory
+
 from ..forms import ProgressForm
 from ..models import Progress
 from ..utils import _Show
@@ -13,7 +15,7 @@ class TestProgressForm:
 
     @pytest.fixture
     def update_show_data(self, mocker):
-        return mocker.patch("project.apps.tmdb.forms.ProgressForm._update_show_data")
+        return mocker.patch("project.apps.tmdb.models.Progress.update_show_data")
 
     @pytest.fixture
     def make_episode_choices(self, mocker):
@@ -21,41 +23,45 @@ class TestProgressForm:
             "project.apps.tmdb.forms.ProgressForm._make_episode_choices", return_value=[1, 2]
         )
 
-    def test_init(self, show, update_show_data, make_episode_choices):
-        initial = {}
-        instance = ProgressFactory.build()
-        form = ProgressForm(initial=initial, instance=instance, user=None, show=show)
+    def test_init_when_not_updating(self, show, update_show_data, make_episode_choices):
+        form = ProgressForm(user=None, show=show)
 
         assert form.user is None
         assert form.show == show
         assert form.fields["last_watched"].choices == [1, 2]
-        update_show_data.assert_called_once_with(initial, instance)
         make_episode_choices.assert_called_once_with()
+        update_show_data.assert_not_called()
+
+    def test_init_when_updating(self, show, update_show_data, make_episode_choices):
+        instance = ProgressFactory.build()
+        form = ProgressForm(instance=instance, user=None, show=show)
+
+        assert form.user is None
+        assert form.show == show
+        assert form.fields["last_watched"].choices == [1, 2]
+        make_episode_choices.assert_called_once_with()
+        update_show_data.assert_called_once_with()
 
     @pytest.mark.django_db
-    def test_update_show_data_called(self, show, make_episode_choices):
-        initial = {
-            "show_name": "Foo",
-            "show_poster_path": "/foo.jpg",
-            "show_status": Progress.ENDED,
-            "last_watched": "1-2",
-        }
-        instance = ProgressFactory(next_air_date=None)
+    def test_save_when_not_updating(self, mocker, update_show_data):
+        update_episodes = mocker.patch("project.apps.tmdb.forms.ProgressForm._update_episodes")
+        user = UserFactory()
+        show = mocker.MagicMock()
+        type(show).id = mocker.PropertyMock(return_value=123)
+        data = {"status": Progress.PAUSED, "last_watched": "0-0"}
+        form = ProgressForm(data=data, user=user, show=show)
 
-        ProgressForm(initial=initial, instance=instance, user=None, show=show)
-        instance.refresh_from_db()
+        assert form.is_valid()
+        progress = form.save()
 
-        assert instance.show_name == initial["show_name"]
-        assert instance.show_poster_path == initial["show_poster_path"]
-        assert instance.show_status == initial["show_status"]
+        update_episodes.assert_called_once_with()
+        update_show_data.assert_called_once_with()
 
-    def test_update_show_data_not_called(self, mocker, show, make_episode_choices):
-        progress = mocker.MagicMock()
-        progress.__bool__.return_value = False
-
-        ProgressForm(initial={}, instance=progress, user=None, show=show)
-
-        progress.save.assert_not_called()
+        assert progress.user == user
+        assert progress.status == data["status"]
+        assert progress.show_id == show.id
+        assert progress.current_season == 0
+        assert progress.current_episode == 0
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
@@ -90,7 +96,7 @@ class TestProgressForm:
             "current_episode": current_episode[1],
         }
         instance = ProgressFactory(next_air_date=None)
-        form = ProgressForm(initial={}, instance=instance, user=None, show=show)
+        form = ProgressForm(instance=instance, user=None, show=show)
         form.cleaned_data = cleaned_data
 
         form._update_episodes()

--- a/project/apps/tmdb/tests/test_forms.py
+++ b/project/apps/tmdb/tests/test_forms.py
@@ -35,7 +35,6 @@ class TestProgressForm:
     @pytest.mark.django_db
     def test_update_show_data_called(self, show, make_episode_choices):
         initial = {
-            "show_id": 1,
             "show_name": "Foo",
             "show_poster_path": "/foo.jpg",
             "show_status": Progress.ENDED,
@@ -46,7 +45,6 @@ class TestProgressForm:
         ProgressForm(initial=initial, instance=instance, user=None, show=show)
         instance.refresh_from_db()
 
-        assert instance.show_id == initial["show_id"]
         assert instance.show_name == initial["show_name"]
         assert instance.show_poster_path == initial["show_poster_path"]
         assert instance.show_status == initial["show_status"]

--- a/project/apps/tmdb/tests/test_models.py
+++ b/project/apps/tmdb/tests/test_models.py
@@ -102,6 +102,7 @@ class TestProgressModel:
         type(show).name = mocker.PropertyMock(return_value="Foo")
         type(show).poster_path = mocker.PropertyMock(return_value="/foo.jpg")
         type(show).status_value = mocker.PropertyMock(return_value="ended")
+        type(show).last_aired_episode = mocker.PropertyMock(return_value=(15, 11))
 
         get_show = mocker.patch("project.apps.tmdb.models.get_show", return_value=show)
 
@@ -113,6 +114,8 @@ class TestProgressModel:
         assert progress.show_name == show.name
         assert progress.show_poster_path == show.poster_path
         assert progress.show_status == show.status_value
+        assert progress.last_aired_season == show.last_aired_episode[0]
+        assert progress.last_aired_episode == show.last_aired_episode[1]
 
     def test_watch_next(self, mocker):
         update_episodes = mocker.patch("project.apps.tmdb.models.Progress._update_episodes")
@@ -171,14 +174,3 @@ class TestProgressModel:
 
         assert progress.next_air_date is None
         get_air_date.assert_not_called()
-
-    def test_update_last_aired_episode(self, mocker):
-        show = mocker.MagicMock()
-        type(show).last_aired_episode = mocker.PropertyMock(return_value=(2, 3))
-        mocker.patch("project.apps.tmdb.models.get_show", return_value=show)
-        progress = ProgressFactory.build()
-
-        progress.update_last_aired_episode()
-
-        assert progress.last_aired_season == 2
-        assert progress.last_aired_episode == 3

--- a/project/apps/tmdb/tests/test_views.py
+++ b/project/apps/tmdb/tests/test_views.py
@@ -12,6 +12,7 @@ class TestWatchNextView:
 
     @pytest.mark.django_db
     def test_post(self, mocker, client):
+        update_show_data = mocker.patch("project.apps.tmdb.models.Progress.update_show_data")
         watch_next = mocker.patch("project.apps.tmdb.models.Progress.watch_next")
         progress = ProgressFactory()
         client.login(username=progress.user.email, password="123123")
@@ -20,6 +21,7 @@ class TestWatchNextView:
         response = client.patch(url, content_type="application/json")
 
         assert response.status_code == 200
+        update_show_data.assert_called_once_with()
         watch_next.assert_called_once_with()
 
 

--- a/project/apps/tmdb/tests/test_views.py
+++ b/project/apps/tmdb/tests/test_views.py
@@ -52,9 +52,6 @@ class TestProgressEditMixin:
             def get_form_kwargs(self):
                 return {"form_kwarg": 123}
 
-            def get_initial(self):
-                return {"initial": 123}
-
         class Dummy(ProgressEditMixin, Base):
             pass
 
@@ -82,19 +79,6 @@ class TestProgressEditMixin:
         assert form_kwargs["user"] == view.request.user
         assert form_kwargs["show"] == view.show
 
-    def test_get_initial(self, mocker, dummy_view_class):
-        view = dummy_view_class()
-        view.show = mocker.MagicMock()
-
-        initial = view.get_initial()
-
-        assert len(initial) == 5
-        assert initial["initial"] == 123
-        assert initial["show_id"] == view.show.id
-        assert initial["show_name"] == view.show.name
-        assert initial["show_poster_path"] == view.show.poster_path
-        assert initial["show_status"] == view.show.status_value
-
 
 class TestProgressUpdateView:
     def test_get_initial(self, mocker):
@@ -109,12 +93,6 @@ class TestProgressUpdateView:
 
         initial = view.get_initial()
 
-        assert len(initial) == 6
-
-        assert initial["show_id"] == show.id
-        assert initial["show_name"] == show.name
-        assert initial["show_poster_path"] == show.poster_path
-        assert initial["show_status"] == show.status_value
-
+        assert len(initial) == 2
         assert initial["status"] == view.object.status
         assert initial["last_watched"] == "0-0"

--- a/project/apps/tmdb/views.py
+++ b/project/apps/tmdb/views.py
@@ -129,16 +129,6 @@ class ProgressEditMixin:
         kwargs.update(user=self.request.user, show=self.show)
         return kwargs
 
-    def get_initial(self):
-        initial = super().get_initial()
-        initial.update(
-            show_id=self.show.id,
-            show_name=self.show.name,
-            show_poster_path=self.show.poster_path,
-            show_status=self.show.status_value,
-        )
-        return initial
-
     def get_success_url(self):
         return self.request.session["progress_edit_success_url"]
 

--- a/project/apps/tmdb/views.py
+++ b/project/apps/tmdb/views.py
@@ -15,6 +15,7 @@ from .utils import get_popular_shows, get_show
 class WatchNextView(LoginRequiredMixin, View):
     def patch(self, request, *args, **kwargs):
         progress = request.user.progress_set.get(show_id=kwargs["show_id"])
+        progress.update_show_data()
         progress.watch_next()
         return HttpResponse()
 


### PR DESCRIPTION
- Move `update_last_aired_episode` logic into `update_show_data`.
- Update show data when clicking `next` button.
- Refactor updating show data on progress page load.

The way we update show data on progresses page load is different as it involves async requests.