### PR TITLE
Fix update_progresses command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `update_progresses` command #67
 
 ## [2.19.0] - 2019-10-04
 ### Added

--- a/project/apps/tmdb/tests/commands/test_update_progresses.py
+++ b/project/apps/tmdb/tests/commands/test_update_progresses.py
@@ -15,7 +15,7 @@ class TestCommand:
     def test_fetch_shows(self, mocker, settings, command):
         show_ids = range(1, 4)
         urls = [f"{settings.TMDB_API_URL}tv/{show_id}" for show_id in show_ids]
-        responses = [mocker.Mock() for _ in show_ids]
+        responses = [mocker.Mock(status_code=200) for _ in show_ids]
         for show_id in show_ids:
             responses[show_id - 1].json.return_value = {"id": show_id}
         fetch_urls = mocker.patch(
@@ -34,6 +34,7 @@ class TestCommand:
         next_air_date = "2019-09-29"
 
         response = mocker.Mock()
+        response.status_code = 200
         response.json.return_value = {"air_date": next_air_date}
         fetch_urls = mocker.patch(
             "project.apps.tmdb.management.commands.update_progresses.Command._fetch_urls",


### PR DESCRIPTION
- Sleep between `_fetch_shows` and `_fetch_next_air_dates`.
- Do not raise error on 404 response from TMDB API.