### PR TITLE
Do not raise exception when updating progresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Do not raise exception when updating progresses #72
+
 ### Removed
 - Health check endpoint #71
 

--- a/project/apps/tmdb/management/commands/update_progresses.py
+++ b/project/apps/tmdb/management/commands/update_progresses.py
@@ -50,8 +50,8 @@ class Command(BaseCommand):
 
     async def _get_show(self, show_id):
         url = f"{settings.TMDB_API_URL}tv/{show_id}"
-        response = await self._fetch(url)
-        return Show(response.json())
+        data = await self._fetch(url)
+        return Show(data)
 
     async def _get_next(self, show, current_season, current_episode):
         next_season, next_episode = show.get_next_episode(current_season, current_episode)
@@ -63,14 +63,14 @@ class Command(BaseCommand):
 
     async def _get_air_date(self, show_id, season, episode):
         url = f"{settings.TMDB_API_URL}tv/{show_id}/season/{season}/episode/{episode}"
-        response = await self._fetch(url)
+        data = await self._fetch(url)
 
         # air_date from response data can be empty string, we want to return
         # None in this case.
-        return response.json().get("air_date") or None
+        return data.get("air_date") or None
 
     async def _fetch(self, url):
         async with httpx.AsyncClient() as client:
             response = await client.get(url, params={"api_key": settings.TMDB_API_KEY})
         response.raise_for_status()
-        return response
+        return response.json()

--- a/project/apps/website/tests/test_views.py
+++ b/project/apps/website/tests/test_views.py
@@ -1,0 +1,75 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.urls import reverse
+
+from project.apps.accounts.tests.factories import UserFactory
+from project.apps.website.views import ContactView
+
+
+class TestIndexView:
+    def test_anonymous_user(self, client):
+        response = client.get(reverse("website:index"))
+
+        assert response.status_code == 302
+        assert response["Location"] == "/popular_shows/"
+
+    @pytest.mark.django_db
+    def test_authenticated_user(self, client):
+        user = UserFactory()
+        client.login(username=user.email, password="123123")
+
+        response = client.get(reverse("website:index"))
+
+        assert response.status_code == 302
+        assert response["Location"] == "/progresses/"
+
+
+class TestContactView:
+    def test_get_initial_anonymous_user(self, mocker):
+        view = ContactView()
+        view.request = mocker.MagicMock(user=AnonymousUser())
+
+        initial = view.get_initial()
+
+        assert initial == {}
+
+    @pytest.mark.django_db
+    def test_get_initial_authenticated_user(self, mocker):
+        user = UserFactory()
+
+        view = ContactView()
+        view.request = mocker.MagicMock(user=user)
+
+        initial = view.get_initial()
+
+        assert initial == {"email": user.email}
+
+    def test_form_valid_anonymous_user(self, mocker):
+        success = mocker.patch("project.apps.website.views.messages.success")
+        form = mocker.MagicMock(instance=mocker.MagicMock(user=None))
+
+        view = ContactView()
+        view.request = mocker.MagicMock(user=AnonymousUser())
+
+        view.form_valid(form)
+
+        assert form.instance.user is None
+        success.assert_called_once_with(
+            view.request, "Your message has been sent, thank you for contacting us."
+        )
+
+    @pytest.mark.django_db
+    def test_form_valid_authenticated_user(self, mocker):
+        success = mocker.patch("project.apps.website.views.messages.success")
+        user = UserFactory()
+        form = mocker.MagicMock(instance=mocker.MagicMock(user=user))
+
+        view = ContactView()
+        view.request = mocker.MagicMock(user=user)
+
+        view.form_valid(form)
+
+        assert form.instance.user == user
+        success.assert_called_once_with(
+            view.request, "Your message has been sent, thank you for contacting us."
+        )


### PR DESCRIPTION
If an exception is raised during the `update_progresses` command, the process is stopped and some progresses won't be updated.

Using `return_exceptions` in `asyncio.gather` solves this problem. It also removes the need to check and skip for 404 status code.