### PR TITLE
Bump python to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: python
-python: 3.7
+python: 3.8
 
 services:
   - docker
@@ -8,7 +8,7 @@ services:
 jobs:
   include:
     - stage: lint_and_test
-      name: "Lint and Test"
+      name: 'Lint and Test'
       if: tag IS blank && branch != qa
       before_install:
         - sudo service postgresql stop
@@ -25,19 +25,19 @@ jobs:
         - coveralls
 
     - stage: deploy
-      name: "Deploy to QA"
+      name: 'Deploy to QA'
       if: tag IS blank && branch = qa
       before_install: skip
       install: skip
       script: skip
-      after_success: echo "Skipping the after_success."  # https://github.com/travis-ci/travis-ci/issues/8337
+      after_success: echo "Skipping the after_success." # https://github.com/travis-ci/travis-ci/issues/8337
       deploy:
         provider: script
         script: sh scripts/deploy.sh qa
         on:
           branch: qa
 
-    - name: "Deploy to Production"
+    - name: 'Deploy to Production'
       if: tag IS present
       script: skip
       deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Capture exceptions when updating progresses #89
 
+### Changed
+- Bump python to 3.8 #90
+
 ## [2.24.0] - 2020-01-01
 ### Changed
 - Bump django version to 3.0.1 #87

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.5-alpine3.10 AS production
+FROM python:3.8.1-alpine3.11 AS production
 
 WORKDIR /app
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 
-asynctest==0.13.0
 bandit==1.6.2
 black==19.3b0
 django-debug-toolbar==2.1


### PR DESCRIPTION
This PR bumps Python to version 3.8.1.

Additionally, also
- bumps Alpine to version 3.11;
- removes PIP dev dependency `asynctest` as Python 3.8 introduced `AsyncMock`.